### PR TITLE
fix line key for case where addressed-infractions is being detected

### DIFF
--- a/erb_lint.rb
+++ b/erb_lint.rb
@@ -66,7 +66,7 @@ fixed_comments = comments_made_by_erb_lint.reject do |comment|
   files_with_offenses.any? do |file|
     file.fetch("path") == comment.fetch("path") &&
       file.fetch("offenses").any? do |offense|
-        offense.fetch("location").fetch("line") == comment.fetch("line")
+        offense.fetch("location").fetch("start_line") == comment.fetch("line")
       end
   end
 end


### PR DESCRIPTION
heres another instance where `start_line` needs to be swapped in -- for when the linter circles back to detect whether an infraction has been cured. in the case that it has, it should remove the comment.